### PR TITLE
Return HTTP Status Code 200

### DIFF
--- a/default.conf.template
+++ b/default.conf.template
@@ -11,8 +11,7 @@ server {
     }
 
     location ${HEALTH_CHECK_PATH} {
-        alias  /usr/share/nginx/html;
-        index  index.html index.htm;
+        return 200;
     }
 
     #error_page  404              /404.html;


### PR DESCRIPTION
Currently `/health` returns `301 redirect` HTTP Status Code.

It is desirable to respond with 200 for health check.
Use the `return 200;` syntax to return HTTP Status Code 200.

I tested that `curl -I` now returns status 200.
```
$ docker build --no-cache=true -t health_check_test:latest .
$ docker run -p 8080:80 health_check_test:latest
$ curl -I http://127.0.0.1:8080/health
HTTP/1.1 200 OK
Server: nginx/1.19.2
Date: Wed, 02 Sep 2020 06:01:37 GMT
Content-Type: application/octet-stream
Content-Length: 0
Connection: keep-alive
```